### PR TITLE
Outline missing for toggling the navigation when using keyboard only

### DIFF
--- a/src/components/global/navbar/_navbar.scss
+++ b/src/components/global/navbar/_navbar.scss
@@ -105,6 +105,10 @@ $navWidthMax: 300px;
   .navbar--toggle {
     display: none;
   }
+  // Avoid focus for checkbox when toggeling of the menu is not needed
+  .navbar--toggle--input {
+    display: none;
+  }
 }
 
 

--- a/src/components/global/navbar/_navbar.scss
+++ b/src/components/global/navbar/_navbar.scss
@@ -184,7 +184,3 @@ $navWidthMax: 300px;
 		}
 	}
 }
-
-
-
-

--- a/src/components/global/navbar/_navbar.scss
+++ b/src/components/global/navbar/_navbar.scss
@@ -150,6 +150,7 @@ $navWidthMax: 300px;
   // Outline the hamburger navigation to toggle the navigation when using the keyboard only
   &:focus + .navbar .navbar--toggle .navbar--toggle--inner {
     outline: 2px dotted var(--theme-color-dark);
+    outline-offset: 6px;
   }
 }
 .navbar--toggle--line {

--- a/src/components/global/navbar/_navbar.scss
+++ b/src/components/global/navbar/_navbar.scss
@@ -146,6 +146,11 @@ $navWidthMax: 300px;
 
 .navbar--toggle--input {
   @include visuallyhidden;
+
+  // Outline the hamburger navigation to toggle the navigation when using the keyboard only
+  &:focus + .navbar .navbar--toggle .navbar--toggle--inner {
+    outline: 2px dotted var(--theme-color-dark);
+  }
 }
 .navbar--toggle--line {
   display: block;


### PR DESCRIPTION
For smaller devices using keyboard only toggling the navigation via checkbox is possible but the outline is missing because the checkbox is visually hidden. Instead of the checkbox we outline the hamburger navigation when the checkbox is in focus so the user know where he is.

![here_is_a_title](https://user-images.githubusercontent.com/95456/40108158-73dd2a1a-58fa-11e8-8158-0808bb6053b9.jpg)
