### PR TITLE
Added „Fork me on GitHub“ only for above-mobile.

### DIFF
--- a/src/components/global/forkme/_forkme-base.scss
+++ b/src/components/global/forkme/_forkme-base.scss
@@ -1,0 +1,39 @@
+#forkMe {
+  display: none;
+}
+@include above-mobile {
+  #forkMe {
+      color: #fff;
+      display: block;
+      text-align: center;
+      text-decoration: none;
+      letter-spacing: .06em;
+      background-color: #A00;
+      padding: 0.5em 5em 0.4em 5em;
+      text-shadow: 0 0 0.75em #444;
+      box-shadow: 0 0 0.5em rgba(0,0,0,0.5);
+      font: bold 16px/1.2em Arial, Sans-Serif;
+      -webkit-text-shadow: 0 0 0.75em #444;
+      -webkit-box-shadow: 0 0 0.5em rgba(0,0,0,0.5);
+      position: absolute;
+      top: 3em;
+      right: -6em;
+      transform: rotate(45deg) scale(0.75,1);
+      z-index:10;
+      -webkit-transform: rotate(45deg) scale(0.75,1);
+  }
+  #forkMe:before {
+      content: '';
+      height: inherit;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      position: absolute;
+      margin: -0.3em -5em;
+      transform: scale(0.7);
+      -webkit-transform: scale(0.7);
+      border: 2px rgba(255,255,255,0.7) dashed;
+  }
+  #forkMe:hover {opacity: 0.9;}
+}

--- a/src/components/global/forkme/forkme.hbs
+++ b/src/components/global/forkme/forkme.hbs
@@ -1,0 +1,1 @@
+<a id="forkMe" href="https://github.com/Access4all/adg">Fork me on GitHub</a>

--- a/src/templates/layout.hbs
+++ b/src/templates/layout.hbs
@@ -17,6 +17,7 @@
 </head>
 <body class="js-theme theme{{#if section }} theme-{{section}}{{/if}}">
   <div id="body">
+    {{> "global/forkme"}}
     <div id="main">
       <header class="header" id="header">
         <div class="l-site_width">


### PR DESCRIPTION
As it overlaps the burger navigation on mobile devices, it is only visible for tablets and above. And I  think it is not handy to browse on GitHub using the mobile so we can omit this there.
![here_is_a_title_und_adg__git_](https://user-images.githubusercontent.com/95456/41038556-e2863522-6996-11e8-80c9-897f552a8994.jpg)
