### PR TITLE
Hide breadcrumb when search is in focus and close search when not in focus

### DIFF
--- a/src/assets/js/app/modules/Search.js
+++ b/src/assets/js/app/modules/Search.js
@@ -41,11 +41,16 @@ export default class Search extends BaseModule {
 
     initializeSs360()
 
-    this.$el.find('.search--toggle').one('click', function () {
+    this.$el.find('.search--toggle').on('click', function () {
+      var breadcrumbs = $('nav.breadcrumbs .breadcrumbs--inner')
+      breadcrumbs.css('visibility', 'hidden')
       $(this)
         .siblings('.search--input')
         .addClass('search--input-expanded')
-        .focus()
+        .focus().focusout(function() {
+          $(this).removeClass('search--input-expanded')
+          breadcrumbs.css('visibility', 'visible')
+        })
     })
   }
 }

--- a/src/assets/js/app/modules/Search.js
+++ b/src/assets/js/app/modules/Search.js
@@ -47,7 +47,8 @@ export default class Search extends BaseModule {
       $(this)
         .siblings('.search--input')
         .addClass('search--input-expanded')
-        .focus().focusout(function() {
+        .focus()
+        .focusout(function () {
           $(this).removeClass('search--input-expanded')
           breadcrumbs.css('visibility', 'visible')
         })

--- a/src/components/global/search/search.hbs
+++ b/src/components/global/search/search.hbs
@@ -1,6 +1,5 @@
 <div class="search js-search" role="search">
 	<h2 class="visuallyhidden">Search</h2>
-	<h3 class="visuallyhidden">Search</h3>
 	<div>
     <button class="search--toggle">
       <span class="visuallyhidden">Show search</span>


### PR DESCRIPTION
Fixes some issues displaying the search #113.
@jmuheim is that not breaking screen reader compatibility?