### PR TITLE
Bolden up inline code examples for better readability.

### DIFF
--- a/src/components/content/text_container/_text_container-base.scss
+++ b/src/components/content/text_container/_text_container-base.scss
@@ -41,7 +41,7 @@
       color: var(--theme-color-dark);
       padding: .1em .25em;
       border-radius: 3px;
-      font-weight: bold;
+      font-weight: 700;
       @include font-xs;
     }
   }

--- a/src/components/content/text_container/_text_container-base.scss
+++ b/src/components/content/text_container/_text_container-base.scss
@@ -41,6 +41,7 @@
       color: var(--theme-color-dark);
       padding: .1em .25em;
       border-radius: 3px;
+      font-weight: bold;
       @include font-xs;
     }
   }


### PR DESCRIPTION
Fixes #150 

> ![colour_contrast_analyser_und_semantics_provide_meaning](https://user-images.githubusercontent.com/95456/42757175-3fe28efa-88ff-11e8-96e5-a65f1097448c.jpg)

> I thought that the examples are sometimes hard to read especially because of the small font. And indeed, the contrast fails on the level of AAA for normal text. I suggest to simply use a black font for the example.

Which is know...
![semantics_provide_meaning](https://user-images.githubusercontent.com/95456/42800022-5a9dc994-899a-11e8-9229-1f2bd846c153.jpg)
