### PR TITLE
Add missing instruction about how to open NVDA's "Elements List"

### DIFF
--- a/pages/examples/headings/handling/README.md
+++ b/pages/examples/headings/handling/README.md
@@ -39,6 +39,7 @@ NVDA's "Elements List" displays a page's heading outline in a tree view. To open
 
 - First make sure you are in browse mode.
     - If unclear to you, see [Screen readers' browse and focus modes](/knowledge/desktop-screen-readers/browse-focus-modes).
+- To open it, press `NVDA + F7`.
 - Press `Alt + H` to select the "Headings" area.
 
 ![NVDA's "Elements List" dialog](_media/nvdas-elements-list-dialog.png)


### PR DESCRIPTION
Seems to have been accidentally stripped away (or has been forgotten) due to some reason.