### PR TITLE
Issue 196: Improve continuous build speed by checking asset changes

### DIFF
--- a/gulp/javascript.js
+++ b/gulp/javascript.js
@@ -10,6 +10,7 @@ module.exports = (config, cb) => {
       rules: [
         {
           test: /\.js$/,
+          include: path.resolve(__dirname, 'src'),
           exclude: /node_modules/,
           loader: 'babel-loader',
           options: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -200,9 +200,16 @@ gulp.task('clean', () => del('./dist'))
 gulp.task(
   'build',
   gulp.series(
-    'clean',
     'sprite',
     gulp.parallel('css', 'js', 'media', 'html', 'html:examples')
+  )
+)
+
+gulp.task(
+  'rebuild',
+  gulp.series(
+    'clean',
+    'build'
   )
 )
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ const css = require('./gulp/css')
 const js = require('./gulp/javascript')
 const examples = require('./gulp/examples')
 const concat = require('gulp-concat')
+const changed = require('gulp-changed')
 
 function errorHandler (err) {
   log(err.plugin || '', colors.cyan(err.fileName), colors.red(err.message))
@@ -108,6 +109,7 @@ gulp.task(
             base: './pages'
           }
         )
+        .pipe(changed('./dist'))
         .pipe(gulp.dest('./dist'))
     },
     function content () {
@@ -115,6 +117,7 @@ gulp.task(
         .src(['./pages/{,**/}_media/**/*', './pages/**/*.{png,jpg,mp3}'], {
           base: './pages'
         })
+        .pipe(changed('./dist'))
         .pipe(gulp.dest('./dist'))
     },
     function assets () {
@@ -122,6 +125,7 @@ gulp.task(
         .src(['./src/assets/img/**/*'], {
           base: './src/assets'
         })
+        .pipe(changed('./dist'))
         .pipe(gulp.dest('./dist'))
     }
   )
@@ -136,6 +140,7 @@ gulp.task('media:resize', () => {
     .src(['./pages/{,**/}_media/**/*', './pages/**/_examples/**/*.png'], {
       base: './pages'
     })
+    .pipe(changed('./dist'))
     .pipe(
       resize({
         sizes: [
@@ -187,8 +192,12 @@ gulp.task('sprite', () => {
         }
       })
     )
-  const imgStream = data.img.pipe(gulp.dest('./src/assets/img/icons'))
-  const cssStream = data.css.pipe(gulp.dest('./tmp'))
+
+  const imgStream = data.img
+    .pipe(changed('./src/assets/img/icons'))
+    .pipe(gulp.dest('./src/assets/img/icons'))
+
+  const cssStream = data.css.pipe(changed('./tmp')).pipe(gulp.dest('./tmp'))
 
   return merge(imgStream, cssStream)
 })
@@ -205,13 +214,7 @@ gulp.task(
   )
 )
 
-gulp.task(
-  'rebuild',
-  gulp.series(
-    'clean',
-    'build'
-  )
-)
+gulp.task('rebuild', gulp.series('clean', 'build'))
 
 gulp.task(
   'default',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -140,7 +140,9 @@ gulp.task('media:resize', () => {
     .src(['./pages/{,**/}_media/**/*', './pages/**/_examples/**/*.png'], {
       base: './pages'
     })
-    .pipe(changed('./dist'))
+    .pipe(changed('./dist', {
+      transformPath: newPath => path.join(path.dirname(newPath), path.basename(newPath, path.extname(newPath)) + '-large' + path.extname(newPath))
+    }))
     .pipe(
       resize({
         sizes: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -6064,6 +6064,45 @@
         }
       }
     },
+    "gulp-changed": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-4.0.2.tgz",
+      "integrity": "sha512-rAvQt+ByaqrMuJLwucvxC+MC02Vh8ksiJ16hoQlk4xnmlHiLJMque2aXXQMmyocQac3RIjNRcyr7iG1TNH15GA==",
+      "dev": true,
+      "requires": {
+        "make-dir": "^3.0.0",
+        "plugin-error": "^1.0.1",
+        "replace-ext": "^1.0.0",
+        "through2": "^3.0.1",
+        "touch": "^3.1.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "gulp-concat": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
@@ -12952,6 +12991,26 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
+    },
+    "touch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "dev": true,
+      "requires": {
+        "nopt": "~1.0.10"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
     },
     "tough-cookie": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "gulp --watch",
     "build": "gulp build",
+    "rebuild": "gulp rebuild",
     "gulp": "gulp",
     "prettier": "prettier-standard '**/*.js'",
     "precommit": "npm run prettier",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "front-matter": "^3.0.2",
     "fs": "0.0.2",
     "gulp": "^4.0.2",
+    "gulp-changed": "^4.0.2",
     "gulp-concat": "^2.6.1",
     "gulp-front-matter": "^1.3.0",
     "gulp-hb": "^8.0.0",


### PR DESCRIPTION
This is intended to fix issue #196 

It splits the `build` command into two commands:
- `rebuild` which destroys the `dist` folder and rebuild everything
- `build` which rebuilds only changed assets

A full rebuild should take between ~35s to ~50s but a single build with only few changes should take ~3s to ~5s.