### PR TITLE
Add Matomo tracking code as well as privacy policy

### DIFF
--- a/pages/introduction/privacy-policy/README.md
+++ b/pages/introduction/privacy-policy/README.md
@@ -22,7 +22,7 @@ We process this usage data in [Matomo Analytics](https://matomo.org/) for statis
 
 ## Cookies
 
-We use cookies (small data files transferred onto computers or devices by sites) for record-keeping purposes and to enhance functionality on our site. You may deactiva
+We use cookies (small data files transferred onto computers or devices by sites) for record-keeping purposes and to enhance functionality on our site. You may deactivate this tracking by deselecting the checkbox below.
 
 ## Opt-out of website tracking
 

--- a/pages/introduction/privacy-policy/README.md
+++ b/pages/introduction/privacy-policy/README.md
@@ -28,5 +28,5 @@ We use cookies (small data files transferred onto computers or devices by sites)
 
 <iframe
         style="border: 0; height: 300px; width: 100%;"
-        src="https://adg-analytics.nothing.ch/index.php?module=CoreAdminHome&action=optOut&language=de&fontColor=272727&fontSize=20px&fontFamily=sans-serif"
+        src="https://adg-analytics.nothing.ch/index.php?module=CoreAdminHome&action=optOut&language=en&fontColor=272727&fontSize=20px&fontFamily=sans-serif"
         ></iframe>

--- a/pages/introduction/privacy-policy/README.md
+++ b/pages/introduction/privacy-policy/README.md
@@ -12,11 +12,11 @@ In order for us to provide you the best possible experience on our guide, we nee
 
 When you visit our site, we will store amongst other things:
 
-- The website from which you visited us from
+- Your referral website (where you came from)
 - The parts of our site you visit
 - The date and duration of your visit
 - Your anonymised IP address
-- Information from the device (device type, operating system, screen resolution, language, country you are located in, and web browser type) you used during your visit
+- Information about your device (device type, operating system, screen resolution, language, country you are located in, and web browser type)
 
 We process this usage data in [Matomo Analytics](https://matomo.org/) for statistical purposes, to improve our site.
 

--- a/pages/introduction/privacy-policy/README.md
+++ b/pages/introduction/privacy-policy/README.md
@@ -1,0 +1,20 @@
+---
+navigation_title: "Privacy Policy"
+position: 5
+changed: "2020-04-30"
+---
+
+# Privacy Policy
+
+In order for us to provide you the best possible experience on our websites, we need to collect and process certain information:
+
+* **Usage data** — when you visit our site, we will store: the website from which you visited us from, the parts of our site you visit, the date and duration of your visit, your anonymised IP address, information from the device (device type, operating system, screen resolution, language, country you are located in, and web browser type) you used during your visit, and more. We process this usage data in Matomo Analytics for statistical purposes, to improve our site.
+* **Cookies** — we use cookies (small data files transferred onto computers or devices by sites) for record-keeping purposes and to enhance functionality on our site. You may deactiva
+
+## Opt-out of website tracking
+
+
+<iframe
+        style="border: 0; height: 300px; width: 100%;"
+        src="https://adg-analytics.nothing.ch/index.php?module=CoreAdminHome&action=optOut&language=de&fontColor=272727&fontSize=20px&fontFamily=sans-serif"
+        ></iframe>

--- a/pages/introduction/privacy-policy/README.md
+++ b/pages/introduction/privacy-policy/README.md
@@ -6,13 +6,25 @@ changed: "2020-04-30"
 
 # Privacy Policy
 
-In order for us to provide you the best possible experience on our websites, we need to collect and process certain information:
+In order for us to provide you the best possible experience on our guide, we need to collect and process certain information.
 
-* **Usage data** — when you visit our site, we will store: the website from which you visited us from, the parts of our site you visit, the date and duration of your visit, your anonymised IP address, information from the device (device type, operating system, screen resolution, language, country you are located in, and web browser type) you used during your visit, and more. We process this usage data in Matomo Analytics for statistical purposes, to improve our site.
-* **Cookies** — we use cookies (small data files transferred onto computers or devices by sites) for record-keeping purposes and to enhance functionality on our site. You may deactiva
+## Usage data
+
+When you visit our site, we will store amongst other things:
+
+- The website from which you visited us from
+- The parts of our site you visit
+- The date and duration of your visit
+- Your anonymised IP address
+- Information from the device (device type, operating system, screen resolution, language, country you are located in, and web browser type) you used during your visit
+
+We process this usage data in [Matomo Analytics](https://matomo.org/) for statistical purposes, to improve our site.
+
+## Cookies
+
+We use cookies (small data files transferred onto computers or devices by sites) for record-keeping purposes and to enhance functionality on our site. You may deactiva
 
 ## Opt-out of website tracking
-
 
 <iframe
         style="border: 0; height: 300px; width: 100%;"

--- a/src/components/global/footer/footer.hbs
+++ b/src/components/global/footer/footer.hbs
@@ -44,7 +44,7 @@
 	  </div>
     <p class="footer--label">
       Further information:
-      <a href="/introduction/license/">Privacy</a> -
+      <a href="/introduction/privacy-policy/">Privacy policy</a> -
       <a href="/introduction/license/">License</a> -
       <a href="/feed/rss.xml">Feed</a> -
       <a href="https://github.com/Access4all/adg/">GitHub</a> -

--- a/src/components/global/footer/footer.hbs
+++ b/src/components/global/footer/footer.hbs
@@ -44,6 +44,7 @@
 	  </div>
     <p class="footer--label">
       Further information:
+      <a href="/introduction/license/">Privacy</a> -
       <a href="/introduction/license/">License</a> -
       <a href="/feed/rss.xml">Feed</a> -
       <a href="https://github.com/Access4all/adg/">GitHub</a> -

--- a/src/components/global/tracking/tracking.hbs
+++ b/src/components/global/tracking/tracking.hbs
@@ -1,0 +1,14 @@
+<!-- Matomo -->
+<script type="text/javascript">
+  var _paq = window._paq || [];
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function () {
+    var u = "https://adg-analytics.nothing.ch/";
+    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+    _paq.push(['setSiteId', '1']);
+    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    g.type = 'text/javascript'; g.async = true; g.defer = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+  })();
+</script>
+<!-- End Matomo Code -->

--- a/src/templates/layout.hbs
+++ b/src/templates/layout.hbs
@@ -33,6 +33,7 @@
     <meta name="{{this.name}}" content="{{this.content}}">
   {{/each}}
   <link rel="alternate" type="application/rss+xml" href="/feed/rss.xml">
+  {{> "global/tracking/tracking"}}
 </head>
 <body class="js-theme theme{{#if section }} theme-{{section}}{{/if}}">
   <div id="body">


### PR DESCRIPTION
According to issue #158, added Matomo trackin code as well as a small privacy policy. The privacy policy is a very stripped own version of [Matomo's privaxy policy](https://matomo.org/docs/privacy/).

The Matomo Instance is configured to only process data coming from https://www.accessibility-developer-guide.com/, therfore date from local development will be ignored.

The Matomo instance is also configured according to the [Matomo Privacy Guide](https://matomo.org/docs/privacy/)