### PR TITLE
Feature/issue 301 crosslink page marking elements with aria

### DIFF
--- a/pages/examples/sensible-aria-usage/expanded/README.md
+++ b/pages/examples/sensible-aria-usage/expanded/README.md
@@ -90,6 +90,8 @@ If you need to describe the expandability status of interactive elements, `aria-
 
 ## You could be also interested in 
 
+Knowledge is power! Our guide has more to offer about:
+
 - [The purpose behind the WAI-ARIA standard](/knowledge/aria/purpose)
 - [Bad ARIA practices](/knowledge/aria/bad-practices)
 - [Sensible usage of ARIA roles and attributes](/examples/sensible-aria-usage)

--- a/pages/examples/sensible-aria-usage/expanded/README.md
+++ b/pages/examples/sensible-aria-usage/expanded/README.md
@@ -87,3 +87,10 @@ While this is even more robust than using `aria-expanded`, it may feel out of pl
 ## Conclusion
 
 If you need to describe the expandability status of interactive elements, `aria-expanded` is one of the few ARIA attributes we truly recommend for general use.
+
+## You could be also interested in 
+
+- [The purpose behind the WAI-ARIA standard](/knowledge/aria/purpose)
+- [Bad ARIA practices](/knowledge/aria/bad-practices)
+- [Sensible usage of ARIA roles and attributes](/examples/sensible-aria-usage)
+


### PR DESCRIPTION
Hi @jmuheim 

Here my proposal for some crosslinks to the page "marking elements with aria", under the examples directory. Basically linked to other aria-pages under "knowledge" and also to the parent page. Please let me know if you see other interesting links for it.

Thank you!