### PR TITLE
Fix Google Lighthouse ’labelledby’ warning

### DIFF
--- a/gulp/html.js
+++ b/gulp/html.js
@@ -215,7 +215,7 @@ module.exports = (config, cb) => {
               url,
               parent: parent !== url ? parent : null,
               title: file.frontMatter.navigation_title,
-              domid: 'nav-' + normalize(file.frontMatter.navigation_title),
+              domid: ('nav-' + normalize(file.frontMatter.navigation_title)).replace(/\s+/g, '-'),
               titleDetailed: file.data.title,
               lead: file.data.lead,
               position: file.frontMatter.position


### PR DESCRIPTION
Fixes #341 by replacing white spaces with dashes.