### PR TITLE
Fix search error

### DIFF
--- a/src/assets/js/lib/vendor/sitesearch360-v12.js
+++ b/src/assets/js/lib/vendor/sitesearch360-v12.js
@@ -2394,7 +2394,7 @@
                       var variable = match.replace(/#/g, '')
                       var replacement = undefined
 
-                      if (replacement === undefined) {
+                      if (replacement === undefined && suggest['dataPoints']) {
                         for (var d = 0; d < suggest['dataPoints'].length; d++) {
                           var dpo = suggest['dataPoints'][d]
 


### PR DESCRIPTION
As reported by Alex in Slack, searching for `aria` does not work as it shows no results and an error is thrown (`TypeError: Cannot read property 'length' of undefined`).

SiteSearch might have updated their API. Until we get a new vendor script, this quick workaround seems to solve this specific issue.

