### PR TITLE
ADG-353 Add rel attribute to footer links

### DIFF
--- a/src/components/global/footer/footer.hbs
+++ b/src/components/global/footer/footer.hbs
@@ -5,7 +5,7 @@
       <p class="footer--label">An initiative of:</p>
       <ul class="footer--agencies">
       <li class="footer--agency">
-        <a class="footer--logolink" href="http://www.access-for-all.ch/" target="_blank" title="Foundation «Access for all»" style="background-image: url(/img/logo/zfa.png);">
+        <a class="footer--logolink" href="http://www.access-for-all.ch/" target="_blank" title="Foundation «Access for all»" style="background-image: url(/img/logo/zfa.png);" rel="noopener noreferrer">
           <img src="/img/logo/zfa.png" alt="Foundation «Access for all»" />
         </a>
       </li>
@@ -15,28 +15,28 @@
 	    <p class="footer--label">In cooperation with:</p>
       <ul class="footer--agencies">
         <li class="footer--agency">
-          <a class="footer--logolink" href="https://www.hinderlingvolkart.com/" target="_blank" title="Hinderling Volkart AG" style="background-image: url(/img/logo/hv.png);">
+          <a class="footer--logolink" href="https://www.hinderlingvolkart.com/" target="_blank" title="Hinderling Volkart AG" style="background-image: url(/img/logo/hv.png);" rel="noopener noreferrer">
             <img src="/img/logo/hv.png" alt="Hinderling Volkart" />
           </a>
         </li>
         <li class="footer--agency">
-          <a class="footer--logolink" href="https://www.unic.com/" target="_blank" title="UNIC AG" style="background-image: url(/img/logo/unic.png);">
+          <a class="footer--logolink" href="https://www.unic.com/" target="_blank" title="UNIC AG" style="background-image: url(/img/logo/unic.png);" rel="noopener noreferrer">
             <img src="/img/logo/unic.png" alt="Unic" />
           </a>
         </li>
         <li class="footer--agency">
-          <a class="footer--logolink" href="https://www.nothing.ch/" target="_blank" title="Nothing AG" style="background-image: url(/img/logo/nothing.png);">
+          <a class="footer--logolink" href="https://www.nothing.ch/" target="_blank" title="Nothing AG" style="background-image: url(/img/logo/nothing.png);" rel="noopener noreferrer">
             <img src="/img/logo/nothing.png" alt="Nothing AG" />
           </a>
         </li>
         <li class="footer--agency">
-          <a class="footer--logolink" href="https://www.liip.ch/" target="_blank" title="Liip AG" style="background-image: url(/img/logo/liip.png);">
+          <a class="footer--logolink" href="https://www.liip.ch/" target="_blank" title="Liip AG" style="background-image: url(/img/logo/liip.png);" rel="noopener noreferrer">
             <img src="/img/logo/liip.png" alt="Liip" />
           </a>
         </li>
         </li>
         <li class="footer--agency">
-          <a class="footer--logolink" href="https://www.zeix.com/" target="_blank" title="Zeix AG" style="background-image: url(/img/logo/zeix.png);">
+          <a class="footer--logolink" href="https://www.zeix.com/" target="_blank" title="Zeix AG" style="background-image: url(/img/logo/zeix.png);" rel="noopener noreferrer">
             <img src="/img/logo/zeix.png" alt="Zeix" />
           </a>
         </li>


### PR DESCRIPTION
I added the `rel="noopener noreferrer"` attribute to the footer links with `target="_blank"` to prevent _reverse tabnabbing attacks_ and get rid of the `Trust and Safety: Links to cross-origin destinations are unsafe` Lighthouse errors.
See https://web.dev/external-anchors-use-rel-noopener/

Closes #353