### PR TITLE
Remove cross browser note for hidden attribute

### DIFF
--- a/pages/examples/hiding-elements/from-all-devices/README.md
+++ b/pages/examples/hiding-elements/from-all-devices/README.md
@@ -1,7 +1,7 @@
 ---
 navigation_title: "From all devices"
 position: 3
-changed: "2018-05-13"
+changed: "2021-06-29"
 ---
 
 # Hiding elements from all devices
@@ -15,16 +15,6 @@ Elements can be hidden completely from all devices (including screen readers).
 In HTML 5, the `hidden` attribute was introduced. It can be set on an element directly and makes it completely invisible to any device.
 
 [Example](_examples/hiding-elements-from-all-devices-using-hidden-attribute)
-
-### Cross browser compatibility
-
-To make the `hidden` attribute work in older browsers, simply do:
-
-```css
-[hidden] {
-   display: none;
-}
-```
 
 ## Using CSS properties
 


### PR DESCRIPTION
The hidden attribute works on 99.48% (source: caniuse.com) of all used browsers worldwide, making a note about backward compatibility more than obsolete and adds more confusion than resolving it, as the guide also keeps it very open what is meant with older browsers.

The major browsers that didn't support it were IE 6 to IE 10 which per caniuse.com currently have a market share of 0.15%.

* [caniuse.com reference for the hidden attribute](https://caniuse.com/hidden)

## What happens for IE10 users?

Well then that element is shown all the time, which we can argue, isn't a breaking problem assuming websites should follow progressive enhancement.

## Review

I can't say who's best fitted to review this content change, so I thought I add:

* Manu and Franco to bring up possible objections considering we're removing information about a fallback for Internet Explorer 10 and older
* Thomas to bring up any objections regarding technical reasons to keep it