### PR TITLE
ADG-360 Fix invisible hamburger menu button

### DIFF
--- a/src/components/global/navbar/_navbar.scss
+++ b/src/components/global/navbar/_navbar.scss
@@ -193,13 +193,20 @@
   left: 50%;
   transform: translate(-50%,-50%);
 
+  @media screen and (-ms-high-contrast: active) {
+    background-color: ButtonFace;
+  }
+
   &:hover {
     .navbar--toggle--line {
       background-color: var(--theme-color-dark);
+
+      @media screen and (-ms-high-contrast: active) {
+        background-color: ButtonText;
+      }
     }
   }
 }
-
 
 .navbar--toggle--input {
   @include visuallyhidden;
@@ -215,17 +222,17 @@
   height: 4px;
   margin-bottom: 6px;
   position: relative;
-
-  background: $c-black;
+  background-color: $c-black;
   border-radius: 3px;
-
   z-index: 1;
-
   transform-origin: 50% 50%;
-
   transition: transform 0.4s cubic-bezier(0.77,0.2,0.05,1.0),
-              background 0.4s cubic-bezier(0.77,0.2,0.05,1.0),
+              background-color 0.4s cubic-bezier(0.77,0.2,0.05,1.0),
               opacity 0.45s ease;
+
+  @media (-ms-high-contrast: active) {
+    background-color: ButtonText;
+  }
 
 	.navbar--toggle--input:checked ~ .navbar .navbar--toggle & {
 	  opacity: 1;


### PR DESCRIPTION
I added the `-ms-high-contrast` media query to change the hamburger menu button’s color.

To make the button visible independent of the user-selected high-contrast theme, I did use Microsoft’s Windows color names.
 
![hcm-01](https://user-images.githubusercontent.com/7314751/124495858-f0497900-ddb8-11eb-8a88-3b30143577c6.png)  
![hcm-02](https://user-images.githubusercontent.com/7314751/124495862-f2133c80-ddb8-11eb-946e-eb3ea1e268c6.png)  
![hcm-03](https://user-images.githubusercontent.com/7314751/124495864-f2abd300-ddb8-11eb-80fe-cebdec509179.png)
 
Fixes #360