### PR TITLE
update instructions for iOS since settings moved

### DIFF
--- a/pages/setup/screen-readers/voiceover-ios/README.md
+++ b/pages/setup/screen-readers/voiceover-ios/README.md
@@ -26,7 +26,7 @@ To be safe, please make sure you have configured the start/stop shortcut (see be
 
 ### Shortcut
 
-The best way to toggle VoiceOver/iOS is to assign it to the accessibility shortcut. Go to `Settings` -> `Accessibility` -> `Shortcut` and select `VoiceOver`. If you are running iOS 12 or older you will find it under `Settings` -> `General` -> `Accessibility` -> `Shortcut`.
+The best way to toggle VoiceOver/iOS is to assign it to the accessibility shortcut. Go to `Settings` -> `Accessibility` -> `Accessibility Shortcut` and select `VoiceOver`. If you are running iOS 12 or older you will find it under `Settings` -> `General` -> `Accessibility` -> `Shortcut`.
 
 Now simply triple tap (press three times in rapid succession) the Home button to turn VoiceOver on or off. VoiceOver says "VoiceOver on" or "VoiceOver off" according to its status.
 

--- a/pages/setup/screen-readers/voiceover-ios/README.md
+++ b/pages/setup/screen-readers/voiceover-ios/README.md
@@ -1,7 +1,7 @@
 ---
 navigation_title: "VoiceOver/iOS"
 position: 1
-changed: "2020-04-07"
+changed: "2023-01-06"
 ---
 
 # VoiceOver/iOS configuration
@@ -26,7 +26,7 @@ To be safe, please make sure you have configured the start/stop shortcut (see be
 
 ### Shortcut
 
-The best way to toggle VoiceOver/iOS is to assign it to the accessibility shortcut. Go to `Settings` -> `General` -> `Accessibility` -> `Shortcut` and select `VoiceOver`.
+The best way to toggle VoiceOver/iOS is to assign it to the accessibility shortcut. Go to `Settings` -> `Accessibility` -> `Shortcut` and select `VoiceOver`. If you are running iOS 12 or older you will find it under `Settings` -> `General` -> `Accessibility` -> `Shortcut`.
 
 Now simply triple tap (press three times in rapid succession) the Home button to turn VoiceOver on or off. VoiceOver says "VoiceOver on" or "VoiceOver off" according to its status.
 


### PR DESCRIPTION
I was looking for instructions to test my site using iOS screen reader and found outdated instructions on how to set it up on [Setup / Screen readers / VoiceOver/iOS](https://www.accessibility-developer-guide.com/setup/screen-readers/voiceover-ios) and found that the accessibility settings had moved.

The change can be seen in the official doc "Get started with accessibility features on iPhone": [iOS 12](https://support.apple.com/guide/iphone/get-started-with-accessibility-features-iph3e2e4367/12.0/ios/12.0) -> [iOS 13](https://support.apple.com/guide/iphone/get-started-with-accessibility-features-iph3e2e4367/13.0/ios/13.0) -> [latest](https://support.apple.com/guide/iphone/get-started-with-accessibility-features-iph3e2e4367/ios).

Here's a [blog post](https://appletoolbox.com/wheres-accessibility-settings-in-ios-13-and-ipados-we-found-it-and-more/) mentioning the change.