### PR TITLE
chore: extract script from ui.js into module

### DIFF
--- a/gulp/helpers/examples.js
+++ b/gulp/helpers/examples.js
@@ -178,7 +178,7 @@ const getExample = (examplePath, filePath) => {
 
   if (compatibility.length) {
     btns.push(`<div class="control">
-      <input type="checkbox" id="${id}-compatibility" name="${id}" value="compatibility" />
+      <input type="checkbox" id="${id}-compatibility" name="${id}" value="compatibility" class="js-panel" />
       <label class="button" for="${id}-compatibility">
         <span class="summary">
           ${compatibilitySummary

--- a/gulp/helpers/examples.js
+++ b/gulp/helpers/examples.js
@@ -158,7 +158,7 @@ const getExample = (examplePath, filePath) => {
     .filter(type => code[type])
     .map(type => {
       return `<div class="control">
-      <input type="checkbox" id="${id}-${type}" name="${id}" value="${type}" />
+      <input type="checkbox" id="${id}-${type}" name="${id}" value="${type}" class="js-panel" />
       <label class="button" for="${id}-${type}">
         <span class="visuallyhidden">Show </span>
         ${type.toUpperCase()}

--- a/src/assets/js/app/modules.js
+++ b/src/assets/js/app/modules.js
@@ -46,6 +46,18 @@ export default () => {
     })
   })
 
+  contextTrigger.add('.js-panel', function () {
+    var elem = this
+
+    require(['./modules/content/Panel'], function (Module) {
+      if (Module.default) {
+        ModuleManager.connect(Module.default, elem)
+      } else {
+        ModuleManager.connect(Module, elem)
+      }
+    })
+  })
+
   contextTrigger.validate('body')
 
   //console.log('Selecting components took: ', new Date() - time, 'ms')

--- a/src/assets/js/app/modules/content/Panel.js
+++ b/src/assets/js/app/modules/content/Panel.js
@@ -1,0 +1,56 @@
+import $ from 'jquery'
+
+import BaseModule from '../BaseModule'
+
+/**
+ * Panel (extracted from `ui.js` for consistency)
+ *
+ * @selector .js-panel
+ * @enabled true
+ */
+export default class Panel extends BaseModule {
+  constructor () {
+    super()
+    this.ns = BaseModule.ns('Panel')
+  }
+
+  init (element) {
+    var DEFAULTS = {}
+    this.$el = $(element)
+    this.config = $.extend(true, {}, DEFAULTS)
+
+    // Make Enter select/deselect checkbox (instead of submitting form)
+    this.$el.keypress(function (e) {
+      if ((e.keyCode ? e.keyCode : e.which) === 13) {
+        return $(this).trigger('click')
+      }
+    })
+
+    this.$el.change(function () {
+      function hideShowPanel (hide, id) {
+        var $trigger = $("[for='" + id + "']")
+        var $panel = $(`#${id}_panel`)
+
+        if (!hide) {
+          $trigger.addClass('is-active')
+          $panel.show()
+        } else {
+          $trigger.removeClass('is-active')
+          $panel.hide()
+        }
+      }
+
+      $("[name='" + $(this).attr('name') + "']")
+        .not($(this))
+        .each(function () {
+          var $btn = $(this)
+          $btn.prop('checked', false)
+          hideShowPanel(true, $btn.attr('id'))
+        })
+
+      return hideShowPanel(!$(this).is(':checked'), $(this).attr('id'))
+    })
+
+    return this
+  }
+}

--- a/src/assets/js/ui.js
+++ b/src/assets/js/ui.js
@@ -5,44 +5,6 @@ import modules from './app/modules'
 
 modules()
 
-$(document).ready(function () {
-  return $("input[type='checkbox']").each((i, element) => {
-    var $checkbox
-    $checkbox = $(element)
-
-    // Make Enter select/deselect checkbox (instead of submitting form)
-    $checkbox.keypress(function (e) {
-      if ((e.keyCode ? e.keyCode : e.which) === 13) {
-        return $(this).trigger('click')
-      }
-    })
-    return $checkbox.change(function () {
-      function hideShowPanel (hide, id) {
-        var $trigger = $("[for='" + id + "']"),
-          $panel = $(`#${id}_panel`)
-
-        if (!hide) {
-          $trigger.addClass('is-active')
-          $panel.show()
-        } else {
-          $trigger.removeClass('is-active')
-          $panel.hide()
-        }
-      }
-
-      $("[name='" + $(this).attr('name') + "']")
-        .not($(this))
-        .each(function () {
-          var $btn = $(this)
-          $btn.prop('checked', false)
-          hideShowPanel(true, $btn.attr('id'))
-        })
-
-      return hideShowPanel(!$(this).is(':checked'), $(this).attr('id'))
-    })
-  })
-})
-
 // Fixed broken skip link, see https://axesslab.com/skip-links/#update-1-a-better-solution
 $(document).ready(function () {
   $('#jump').click(function (e) {


### PR DESCRIPTION
This PR extracts "inline" code from `ui.js` into a separate `Panel` module. This improves consistency and will simplify future refactoring.

In addition, it makes sure that this code is not executed on every checkbox but only on the ones with a `js-panel` class. As of now this applies to the `HTML`, `CSS`, `JS` and compatibility tabs used for code examples.