### PR TITLE
chore: handle windows path separators when building html

### DIFF
--- a/gulp/html.js
+++ b/gulp/html.js
@@ -230,7 +230,10 @@ module.exports = (config, cb) => {
           try {
             const layout = getLayout(file.frontMatter.layout, layouts)
             const relPath = path.relative('./pages', file.path)
-            const currentUrl = relPath.substring(0, relPath.lastIndexOf('/'))
+            const currentUrl = relPath.substring(
+              0,
+              relPath.lastIndexOf(path.sep)
+            )
             const prevNext = {}
             const breadcrumb = []
             const subPages = []
@@ -296,6 +299,7 @@ module.exports = (config, cb) => {
           return path
             .relative('./src/components', file.path)
             .replace(path.extname(file.path), '')
+            .replace(new RegExp('\\' + path.sep, 'g'), '/')
         },
         helpers: {
           formatDate: datetime.formatDate,


### PR DESCRIPTION
The `html` task is throwing an error on Windows as partials cannot be found due to Windows using `\` rather than `/` as path separator.

NOTE: As the `media:resize` task is Windows-incompatible, too, this change is targeting `feature/image-resize` where the resizing has been fixed. https://github.com/Access4all/adg/pull/396 should be merged first.