### PR TITLE
chore: windows path issues

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,5 +3,6 @@ module.exports = {
   tabWidth: 2,
   semi: false,
   singleQuote: true,
-  arrowParens: 'avoid'
+  arrowParens: 'avoid',
+  endOfLine: 'auto'
 }

--- a/gulp/html.js
+++ b/gulp/html.js
@@ -13,10 +13,13 @@ const { Readable } = require('stream')
 const _ = require('lodash')
 const { JSDOM } = require('jsdom')
 
+const pathSeparatorRegExp = new RegExp('\\' + path.sep, 'g')
+
 const getUrl = (filePath, base) => {
   return path
     .relative(base, filePath)
     .replace(path.basename(filePath), '')
+    .replace(pathSeparatorRegExp, '/')
     .replace(/\/$/, '')
 }
 
@@ -231,10 +234,9 @@ module.exports = (config, cb) => {
           try {
             const layout = getLayout(file.frontMatter.layout, layouts)
             const relPath = path.relative('./pages', file.path)
-            const currentUrl = relPath.substring(
-              0,
-              relPath.lastIndexOf(path.sep)
-            )
+            const currentUrl = relPath
+              .substring(0, relPath.lastIndexOf(path.sep))
+              .replace(pathSeparatorRegExp, '/')
             const prevNext = {}
             const breadcrumb = []
             const subPages = []
@@ -300,7 +302,7 @@ module.exports = (config, cb) => {
           return path
             .relative('./src/components', file.path)
             .replace(path.extname(file.path), '')
-            .replace(new RegExp('\\' + path.sep, 'g'), '/')
+            .replace(pathSeparatorRegExp, '/')
         },
         helpers: {
           formatDate: datetime.formatDate,

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build": "gulp build",
     "rebuild": "gulp rebuild",
     "gulp": "gulp",
-    "lint": "eslint --fix '**/*.js'",
-    "format": "prettier --write '**/*.{js,scss}'",
+    "lint": "eslint --fix \"**/*.js\"",
+    "format": "prettier --write \"**/*.{js,scss}\"",
     "update": "npx npm-check -u",
     "prepare": "husky install"
   },


### PR DESCRIPTION
- Due to incompatibilities with `\` when building the HTML, there were issues with the navigation and the theme when running  the process on Windows. Specifically, the navigation was not properly nested as parent pages were not detected by path, and the theme class on the body was invalid.
- The formatting scripts did not properly run as the file paths were incorrectly quoted on Windows. When fixing this I stumbled upon the need for a `endOfLine` setting for prettier in order to prevent Windows from reformatting everything.