### PR TITLE
docs: remove references to slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We welcome everyone who wants to join our initiative, be it with adding new cont
 
 ## Communication
 
-In addition to using issues and PRs to dicuss topics, we use Slack for general communication: [Join ADG Slack team](https://join.slack.com/t/a11y-dev-guide/shared_invite/enQtMzMwOTkxNTI3NDYwLTFkOTA5YmEwYjc5ZWU4OTJmZmZmYTJlNzFlNWQ0ZGU3MzQ0ZjQ1ODc3ZGFiY2MzYThkOTVkM2ZhNGQ0ZTZhZDE)!
+We use issues and pull requests to discuss topics.
 
 ## Technical details
 

--- a/pages/contribute/README.md
+++ b/pages/contribute/README.md
@@ -1,7 +1,7 @@
 ---
-navigation_title: "Contribute"
+navigation_title: 'Contribute'
 position: 5
-changed: "2021-05-03"
+changed: '2021-05-03'
 ---
 
 # Contribute to this guide
@@ -14,21 +14,11 @@ We welcome everyone who wants to join our initiative, be it with adding new cont
 
 Let us make the Internet a more accessible place together!
 
-## Discuss about accessibility and the guide
-
-Come and [join our Slack team] or [create an issue on GitHub].
-
-## Contribute code
-
-Improve the guide by fixing bugs or adding code examples. The code is completely open-source and can be found on GitHub under [Access4all/adg (GitHub.com)].
-
-We are happy about issues and pull requests. Please refer to our contribution guidelines: [Access4all/adg/CONTRIBUTING.md (GitHub.com)].
-
 ## Share your knowledge
 
-Help to improve the content of the guide by adding new chapters or improving existing ones. [Join our Slack team] to discuss about your contribution and how to send it in, create an issue or a pull request on our GitHub project [Access4all/adg (GitHub.com)] to show us your proposal directly.
+Found a bug or want to add something new? Help us improve the content of the guide by adding chapters or improving existing ones. Please let us know by creating an issue or pull request on our GitHub project [Access4all/adg (GitHub.com)].
 
-Also, we appreciate if you found mistakes or outdated sections in the guide. Please let us know.
+Before opening a pull request we recommend reading our contribution guidelines: [Access4all/adg/CONTRIBUTING.md (GitHub.com)].
 
 ## Meet us at our hackdays
 
@@ -41,10 +31,13 @@ You can also contribute by spreading awareness about the topic to your fellow de
 - **Share the guide on Twitter** and other channels if you find it useful and want to give something back. We're also available on Twitter under [@A11yDevGuide (Twitter.com)] and on [Facebook].
 - **Talk about accessibility at your local meetup**. Feel free to use the guide as resource. We appreciate every developer who is concerned about accessibility. Let us know so we can share your event.
 
-[join our slack team]: https://join.slack.com/t/a11y-dev-guide/shared_invite/zt-481zt544-HZCboLee6JL__6LnHl1N5w
 [create an issue on github]: https://github.com/Access4all/adg/issues
 [access4all/adg (github.com)]: https://github.com/Access4all/adg
 [access4all/adg/contributing.md (github.com)]: https://github.com/Access4all/adg/blob/master/CONTRIBUTING.md
 [join our meetup.com group]: https://www.meetup.com/accessibility-community-meetup/
 [@a11ydevguide (twitter.com)]: https://twitter.com/A11yDevGuide
 [facebook]: https://www.facebook.com/AccessibilityDeveloperGuide
+
+## Community
+
+We recommend the [Accessibility Club slack team](https://slack.a11y.club) to talk to like-minded people. It is not affiliated with this project in any way, but many of our contributors are members there.

--- a/pages/contribute/README.md
+++ b/pages/contribute/README.md
@@ -1,7 +1,7 @@
 ---
 navigation_title: 'Contribute'
 position: 5
-changed: '2021-05-03'
+changed: '2023-05-19'
 ---
 
 # Contribute to this guide

--- a/src/components/global/footer/footer.hbs
+++ b/src/components/global/footer/footer.hbs
@@ -49,7 +49,7 @@
       <a href="/feed/rss.xml">Feed</a> -
       <a href="https://github.com/Access4all/adg/">GitHub</a> -
       <a href="https://www.facebook.com/AccessibilityDeveloperGuide">Facebook</a> -
-      <a href="https://twitter.com/A11yDevGuide">Twitter</a> -
+      <a href="https://twitter.com/A11yDevGuide">Twitter</a>
     </p>
     <p class="footer--label">
       Based strictly on <a href="https://www.w3.org/">W3C</a>'s <a href="https://www.w3.org/TR/WCAG21/">WCAG 2.1</a> and <a href="https://www.w3.org/TR/WCAG20-TECHS/aria">ARIA</a> |

--- a/src/components/global/footer/footer.hbs
+++ b/src/components/global/footer/footer.hbs
@@ -50,7 +50,6 @@
       <a href="https://github.com/Access4all/adg/">GitHub</a> -
       <a href="https://www.facebook.com/AccessibilityDeveloperGuide">Facebook</a> -
       <a href="https://twitter.com/A11yDevGuide">Twitter</a> -
-      <a href="https://join.slack.com/t/a11y-dev-guide/shared_invite/zt-481zt544-HZCboLee6JL__6LnHl1N5w">Slack</a>
     </p>
     <p class="footer--label">
       Based strictly on <a href="https://www.w3.org/">W3C</a>'s <a href="https://www.w3.org/TR/WCAG21/">WCAG 2.1</a> and <a href="https://www.w3.org/TR/WCAG20-TECHS/aria">ARIA</a> |


### PR DESCRIPTION
As our Slack team is not really active anymore I would recommend the following:
- Removing references to it and suggesting issues as main way of communicating.
- Adding a link to the lively `Accessibility Club` Slack team instead.
- Closing the Slack team.

What does this change achieve:
- We can lead people to an active community where they can post any question about accessibility and get a quick answer.
- Questions about the ADG itself are answered here instead of here and in Slack.
- We don't have to maintain a Slack team.