### PR TITLE
Removed unneccessary page scroll

### DIFF
--- a/src/assets/css/_base.scss
+++ b/src/assets/css/_base.scss
@@ -1,6 +1,5 @@
 html {
   width: 100%;
-  overflow-x: hidden;
   font-size: $base-font-size;
   font-size: $base-font-size / 16px * 100%;
   @include tablet {


### PR DESCRIPTION
There was a scroll on the page that wasn't meant to be there -- it would scroll a few pixels and stop. This got in the way of the main scroll, and was causing a cumbersome experience throughout the website.

Here's what it looked like:
<kbd>![Screenshot 2023-05-30 at 1 56 23 PM](https://github.com/Access4all/adg/assets/42309026/9ba358d5-7cd1-422c-b2ca-92c11b5a7b05)</kbd>

I've removed the `overflow-x: hidden;` rule from the `html` property in CSS, and that seemed to have worked. I haven't noticed any unusual bugs or side effects once I removed that, so kindly let me know if you spot one.
