### PR TITLE
Update commit date format for feed use

### DIFF
--- a/gulp/html.js
+++ b/gulp/html.js
@@ -258,7 +258,7 @@ module.exports = (config, cb) => {
             }
             const { stdout: dateChanged } = child_process.spawnSync(
               'git',
-              ['log', '-1', '--pretty=format:%cs', file.path],
+              ['log', '-1', '--pretty=format:%ci', file.path],
               { encoding: 'utf8' }
             )
 


### PR DESCRIPTION
The files in the `/dist/feed/` folder are locally no longer generated (after a macOS update?) because apparently an invalid Date object is passed to Feed.
And that's why the Gulp task `html` is aborted:

```
% npm start
...
[] 'html' errored after 9.62 s
RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at /Users/chd/adg/node_modules/feed/lib/json.js:51:48
    at Array.map (<anonymous>)
    at Object.default (/Users/chd/adg/node_modules/feed/lib/json.js:33:24)
    at Feed.json1 (/Users/chd/adg/node_modules/feed/lib/feed.js:20:57)
    at Pumpify.<anonymous> (/Users/chd/adg/gulp/html.js:411:47)
    at Pumpify.emit (node:events:529:35)
    at Pumpify.emit (node:domain:552:15)
    at finishMaybe (/Users/chd/adg/node_modules/readable-stream/lib/_stream_writable.js:630:14)
    at afterWrite (/Users/chd/adg/node_modules/readable-stream/lib/_stream_writable.js:492:3)
    at onwrite (/Users/chd/adg/node_modules/readable-stream/lib/_stream_writable.js:483:7)
    at WritableState.onwrite (/Users/chd/adg/node_modules/readable-stream/lib/_stream_writable.js:180:5)
    at Object.onceWrapper (node:events:631:28)
    at Pumpify.emit (node:events:517:28)
    at Pumpify.emit (node:domain:552:15)
    at Duplexify.uncork (/Users/chd/adg/node_modules/duplexify/index.js:77:50)
    at /Users/chd/adg/node_modules/pumpify/index.js:47:12
    at /Users/chd/adg/node_modules/pumpify/node_modules/pump/index.js:75:7
    at f (/Users/chd/adg/node_modules/once/once.js:25:25)
    at DestroyableTransform.<anonymous> (/Users/chd/adg/node_modules/pumpify/node_modules/pump/index.js:33:5)
    at DestroyableTransform.f (/Users/chd/adg/node_modules/once/once.js:25:25)
    at DestroyableTransform.onfinish (/Users/chd/adg/node_modules/end-of-stream/index.js:31:27)
    at DestroyableTransform.emit (node:events:529:35)
    at DestroyableTransform.emit (node:domain:552:15)
    at finishMaybe (/Users/chd/adg/node_modules/readable-stream/lib/_stream_writable.js:630:14)
    at afterWrite (/Users/chd/adg/node_modules/readable-stream/lib/_stream_writable.js:492:3)
    at onwrite (/Users/chd/adg/node_modules/readable-stream/lib/_stream_writable.js:483:7)
    at WritableState.onwrite (/Users/chd/adg/node_modules/readable-stream/lib/_stream_writable.js:180:5)
    at DestroyableTransform.afterTransform (/Users/chd/adg/node_modules/readable-stream/lib/_stream_transform.js:93:3)
    at onWritten (/Users/chd/adg/node_modules/vinyl-fs/lib/dest/write-contents/index.js:51:7)
    at onClosed (/Users/chd/adg/node_modules/vinyl-fs/lib/file-operations.js:26:5)
    at /Users/chd/adg/node_modules/graceful-fs/graceful-fs.js:61:14
    at FSReqCallback.oncomplete (node:fs:192:23)
    at FSReqCallback.callbackTrampoline (node:internal/async_hooks:128:17)
[] 'build' errored after 10 s
[] 'default' errored after 10 s
```

Changing the commit date format from [%cs](https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emcsem) to [%ci](https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emciem) in `html.js` seems to fix it.