### PR TITLE
ADG-420 Build warnings

### DIFF
--- a/gulp/javascript.js
+++ b/gulp/javascript.js
@@ -35,7 +35,15 @@ module.exports = (config, cb) => {
       filename: '[name].js',
       chunkFilename: 'async/[name].js',
       publicPath: config.publicPath
-    }
+    },
+    ignoreWarnings: [
+      // `app/modules.js` is using `require(['something'])` and we can safely ignore this
+      {
+        module: /ModuleManager\.js/,
+        message:
+          /Critical dependency: the request of a dependency is an expression/
+      }
+    ]
   })
 
   const log = (err, stats) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3717,9 +3717,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001482",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz",
-      "integrity": "sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==",
+      "version": "1.0.30001594",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001594.tgz",
+      "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
This PR gets rid of the Webpack warning `Critical dependency: the request of a dependency is an expression`. It is triggered by somewhat outdated source code (see `app/modules.js`), but we don't care about this specific warning.

It additionally updates `caniuse-lite` to get rid of the `Browserslist: caniuse-lite is outdated` warning when building.

Fixes #420 