### PR TITLE
fix: search suggestions in nvda

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -259,6 +259,7 @@ gulp.task(
       ['./src/assets/css/**/*.scss', './src/components/**/*.scss'],
       gulp.series('css')
     )
+    gulp.watch(['./src/assets/js/**/*.js'], gulp.series('js'))
     gulp.watch(
       [
         './pages/**/*.md',

--- a/src/assets/js/lib/vendor/sitesearch360-v12.js
+++ b/src/assets/js/lib/vendor/sitesearch360-v12.js
@@ -2248,7 +2248,7 @@
               var suggestSet = Object(
                 _sxQuery_sxQuery__WEBPACK_IMPORTED_MODULE_0__[/* default */ 'a']
               )(
-                '<section class="unibox-suggest-cluster unibox-suggest-' +
+                '<div class="unibox-suggest-cluster unibox-suggest-' +
                   cssKey +
                   ' ' +
                   ('unibox-' + values.length + '-entries') +
@@ -2258,7 +2258,7 @@
                     : '') +
                   '" ' +
                   labelledBy +
-                  '></section>'
+                  '></div>'
               )
 
               if (key.replace(/_/, '').length > 0 && values.length > 0) {


### PR DESCRIPTION
Changing `section` to `div` in the suggestion wrapper allows Firefox (132) and NVDA (2024.4) to read search suggestions when cycling through them via arrow keys.

![image](https://github.com/user-attachments/assets/3a1ecefc-6658-4602-a373-939767b32338)

- Before: https://www.accessibility-developer-guide.com/
- After: https://deploy-preview-450--accessibility-developer-guide.netlify.app/

The solution still feels very hacky (I would argue the markup could be way simpler), but this could be a solution until we completely replace it.