### PR TITLE
fix: typo in CSS selector

### DIFF
--- a/pages/examples/sensible-aria-usage/describedby/README.md
+++ b/pages/examples/sensible-aria-usage/describedby/README.md
@@ -30,7 +30,7 @@ Using `aria-describedby`, any number of elements can be set as description(s) of
 By the way, elements hidden using CSS can still be referenced:
 
 ```css
-##description {
+#description {
   display: none;
 }
 ```


### PR DESCRIPTION
Fixes a typo in a CSS selector.