### PR TITLE
Create information page on the EAA

### DIFF
--- a/pages/knowledge/aria/README.md
+++ b/pages/knowledge/aria/README.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "ARIA"
-position: 2
+position: 3
 ---
 
 # ARIA - when HTML simply is not enough

--- a/pages/knowledge/colours-and-contrast/README.md
+++ b/pages/knowledge/colours-and-contrast/README.md
@@ -5,8 +5,8 @@ position: 1
 
 # Colours and contrast
 
-**Visual elements like for example text, icons, input fields and charts need to be easily perceivable. On the most basic level that means that they have to clearly stand out from their background. But it's also important that they can be easily distinguished from similar elements around them – for example links embedded in a text paragraph.** 
+**Visual elements like for example text, icons, input fields and charts need to be easily perceivable. On the most basic level that means that they have to clearly stand out from their background. But it's also important that they can be easily distinguished from similar elements around them – for example links embedded in a text paragraph.**
 
 The need to see things clearly is a shared one among people who rely on their eyes. But the challenges are quite diverse. People with a visual impairment might not be able to see (certain) colours, their field of view might be blurred or very narrow. But it's also possible that the challenge is caused by a beamer projection in a light room or direct sunlight shining on the screen.
 
-The visual contrast between different colours is a key factor in making things perceivable. But colour contrast has its limitations. Creating robust visual differences between elements often requires a more holistic approach. 
+The visual contrast between different colours is a key factor in making things perceivable. But colour contrast has its limitations. Creating robust visual differences between elements often requires a more holistic approach.

--- a/pages/knowledge/keyboard-only/README.md
+++ b/pages/knowledge/keyboard-only/README.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Keyboard only"
-position: 3
+position: 4
 ---
 
 # Introduction to keyboard only usage

--- a/pages/knowledge/legal/README.md
+++ b/pages/knowledge/legal/README.md
@@ -1,0 +1,9 @@
+---
+navigation_title: 'Legal requirements'
+position: 7
+card_text: "Accessibility is no longer optional. Many countries now enforce it through comprehensive legislation, transforming inclusive design from a voluntary practice into a mandatory requirement."
+---
+
+# Legal requirements for accessibility
+
+Digital accessibility has evolved from a purely social and ethical responsibility into a strict legal mandate. While ensuring that everyone can participate in the digital world remains a fundamental moral imperative, an increasing number of countries now enforce accessibility through comprehensive legislation, transforming inclusive design from a voluntary "nice-to-have" into a mandatory requirement for digital products and services.

--- a/pages/knowledge/legal/README.md
+++ b/pages/knowledge/legal/README.md
@@ -6,4 +6,4 @@ card_text: "Accessibility is no longer optional. Many countries now enforce it t
 
 # Legal requirements for accessibility
 
-Digital accessibility has evolved from a purely social and ethical responsibility into a strict legal mandate. While ensuring that everyone can participate in the digital world remains a fundamental moral imperative, an increasing number of countries now enforce accessibility through comprehensive legislation, transforming inclusive design from a voluntary "nice-to-have" into a mandatory requirement for digital products and services.
+While ensuring that everyone can participate in the digital world remains a fundamental moral imperative, an increasing number of countries now enforce accessibility through comprehensive legislation, transforming inclusive design from a voluntary "nice-to-have" into a mandatory requirement for digital products and services.

--- a/pages/knowledge/legal/eaa/README.md
+++ b/pages/knowledge/legal/eaa/README.md
@@ -1,7 +1,7 @@
 ---
 navigation_title: 'European Accessibility Act'
 position: 1
-card_text: "The European Accessibility Act (EAA) defines accessibility requirements for a wide range of products and services sold or provided in the European Union"
+card_text: "The European Accessibility Act (EAA) defines accessibility requirements for a wide range of products and services sold or provided in the European Union."
 ---
 
 # European Accessibility Act
@@ -59,6 +59,6 @@ Accessibility is therefore not a one‑off task but an **ongoing responsibility*
 
 ## Further reading
 
-For a more detailed discussion of the European Accessibility Act and its national implementation in Germany (BFSG), we recommend the following in‑depth overview by tollwerk (in German):
+For a more detailed discussion of the European Accessibility Act and its national implementation in Germany (BFSG), we recommend the following in‑depth overview by tollwerk:
 
-https://tollwerk.de/blog/european-accessibility-act-eaa-barrierefreiheitsstaerkungsgesetz-bfsg{ target=_blank hreflang=de }
+[European Accessibility Act – Barrierefreiheit für die Privatwirtschaft (in German)](https://tollwerk.de/blog/european-accessibility-act-eaa-barrierefreiheitsstaerkungsgesetz-bfsg){ target=_blank hreflang=de }

--- a/pages/knowledge/legal/eaa/README.md
+++ b/pages/knowledge/legal/eaa/README.md
@@ -1,0 +1,58 @@
+---
+navigation_title: 'European Accessibility Act'
+position: 1
+card_text: "The European Accessibility Act (EAA) defines accessibility requirements for a wide range of products and services sold or provided in the European Union"
+---
+
+# European Accessibility Act
+
+The European Accessibility Act (EAA) is a key piece of EU legislation designed to harmonise accessibility requirements across all member states. Its purpose is to ensure that people with disabilities can access products and services independently, both in physical and digital environments.
+
+[[_TOC_]]
+
+## What is the EAA?
+
+The European Accessibility Act (EAA), formally known as [Directive (EU) 2019/882](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882){ target=_blank }, sets out **uniform accessibility rules** for products and services offered across the EU. The directive aims to support social inclusion and create a more consistent internal market by removing fragmentation caused by differing national regulations.
+
+As of 28 June 2025, any organisation providing covered products or services within the EU must comply with the directive. For design, development and content teams, this means ensuring that all digital touchpoints meet **all 50 WCAG 2.1 Level A and AA success criteria**.
+
+## Who and what is affected?
+
+The EAA applies to a broad range of consumer‑facing products and services made available in the EU, regardless of where an organisation is based. It covers both hardware and essential digital services.
+
+**Key services covered include:**
+
+- **E-commerce platforms** offering products or services online
+- **Banking and financial services,** including electronic signatures and payment processes
+- **Online booking systems,** including business-relevant processes like appointment scheduling and time-slot reservations
+- **Passenger transport services,** including websites and apps for air, bus, rail and ship travel
+- **E-books** and the software used to access and read them
+
+The directive also defines important **exceptions:**
+
+It does not apply to strictly B2B services with no interaction involving natural persons. It excludes legacy media or static office documents (such as PDFs) published before June 2025. **Microenterprises** with fewer than 10 employees and an annual turnover below €2 million are generally exempt from the service requirements.
+
+## What happens if you don’t comply?
+
+EU Member States must establish enforcement mechanisms that are effective, proportionate and dissuasive. These ensure that non‑compliance cannot be treated as a viable alternative to meeting accessibility obligations.
+
+**Enforcement measures include:**
+
+- **Mandatory remediation:** Authorities may require the operator to resolve accessibility issues within a defined timeframe.
+- **Fines:** Financial penalties vary by Member State and can accumulate across different EU markets where the same non‑compliant service is offered.
+- **Product withdrawal:** Authorities can restrict or prohibit a product or service from being made available in the EU if corrective measures are not taken.
+- **Legal liabilities:** Organisations may face compensation claims, contractual issues and reputational damage.
+
+## Why compliance is a business advantage
+
+Compliance is not only about risk mitigation. Accessible design **improves the user experience for everyone,** strengthens brand trust and opens access to broader audience segments.
+
+From a technical perspective, adhering to standards leads to cleaner, more maintainable code, reduces long‑term development costs and contributes to better technical SEO.
+
+## Code and content: A shared responsibility
+
+While the EAA defines the legal and technical framework, accessibility cannot be delivered through code alone. Implementing technically correct solutions is essential, but long‑term accessibility relies on **continuous collaboration across teams.**
+
+Developers can ensure semantic markup, ARIA correctness and keyboard operability. However, content quality plays an equally important role. For example, an image with a technically valid alt attribute is still inaccessible if the provided text is incomplete or unclear. True compliance requires accessibility to be **embedded throughout the entire content lifecycle.**
+
+Accessibility is therefore not a one‑off task but an **ongoing responsibility** involving design, development and editorial teams. An accessible website is a living product that succeeds only when everyone maintains a consistent commitment to inclusion.

--- a/pages/knowledge/legal/eaa/README.md
+++ b/pages/knowledge/legal/eaa/README.md
@@ -14,7 +14,7 @@ The European Accessibility Act (EAA) is a key piece of EU legislation designed t
 
 The European Accessibility Act (EAA), formally known as [Directive (EU) 2019/882](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882){ target=_blank }, sets out **uniform accessibility rules** for products and services offered across the EU. The directive aims to support social inclusion and create a more consistent internal market by removing fragmentation caused by differing national regulations.
 
-As of 28 June 2025, any organisation providing covered products or services within the EU must comply with the directive. For design, development and content teams, this means ensuring that all digital touchpoints meet **all 50 WCAG 2.1 Level A and AA success criteria**.
+As of 28 June 2025, any organisation providing covered products or services within the EU must comply with the [European Standard <nobr>EN 301 549</nobr>](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf){ target=_blank }. As part of its requirements, this standard mandates that design, development and content teams ensure that **all 50 WCAG 2.1 Level A and AA success criteria** are fulfilled across all digital touchpoints.
 
 ## Who and what is affected?
 
@@ -59,6 +59,6 @@ Accessibility is therefore not a one‑off task but an **ongoing responsibility*
 
 ## Further reading
 
-For a more detailed discussion of the European Accessibility Act and its national implementation in Germany (BFSG), we recommend the following in‑depth overview by tollwerk:
+For a more detailed discussion of the European Accessibility Act and its national implementation in Germany (BFSG), we recommend the following in‑depth overview by Tollwerk:
 
 [European Accessibility Act – Barrierefreiheit für die Privatwirtschaft (in German)](https://tollwerk.de/blog/european-accessibility-act-eaa-barrierefreiheitsstaerkungsgesetz-bfsg){ target=_blank hreflang=de }

--- a/pages/knowledge/legal/eaa/README.md
+++ b/pages/knowledge/legal/eaa/README.md
@@ -56,3 +56,9 @@ While the EAA defines the legal and technical framework, accessibility cannot be
 Developers can ensure semantic markup, ARIA correctness and keyboard operability. However, content quality plays an equally important role. For example, an image with a technically valid alt attribute is still inaccessible if the provided text is incomplete or unclear. True compliance requires accessibility to be **embedded throughout the entire content lifecycle.**
 
 Accessibility is therefore not a one‑off task but an **ongoing responsibility** involving design, development and editorial teams. An accessible website is a living product that succeeds only when everyone maintains a consistent commitment to inclusion.
+
+## Further reading
+
+For a more detailed discussion of the European Accessibility Act and its national implementation in Germany (BFSG), we recommend the following in‑depth overview by tollwerk (in German):
+
+https://tollwerk.de/blog/european-accessibility-act-eaa-barrierefreiheitsstaerkungsgesetz-bfsg{ target=_blank hreflang=de }

--- a/pages/knowledge/semantics/README.md
+++ b/pages/knowledge/semantics/README.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Semantics"
-position: 1
+position: 2
 ---
 
 # Semantics and their importance for accessibility

--- a/pages/knowledge/web-components/README.md
+++ b/pages/knowledge/web-components/README.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: 'Web Components'
-position: 5
+position: 6
 ---
 
 # Web Components


### PR DESCRIPTION
Here is an initial version of the content page with information about the EAA. Further additions and improvements are very welcome.

https://deploy-preview-472--accessibility-developer-guide.netlify.app/knowledge/legal/eaa/

As suggested in the issue, I have included a link to the tollwerk blog post. Even though it may be somewhat unusual to direct users from an English page to a German‑language resource.

Closes #434 