### PR TITLE
ADG-478 - recent changes attribution

### DIFF
--- a/config/recent-pages.js
+++ b/config/recent-pages.js
@@ -16,6 +16,7 @@ export default [
   },
   {
     commit: '517667bf917d002ea45092af00df472130d23f90',
+    authorCommit: '2d8ca741419fc31b380d831c7137c2608020e0be',
     pages: ['setup/windows/vmware-on-macos']
   },
   {

--- a/config/recent-pages.js
+++ b/config/recent-pages.js
@@ -1,14 +1,14 @@
 export default [
   {
+    commit: '2ee186fb4cd43afe66a10d9cad8f849365277103',
+    pages: ['introduction/about']
+  },
+  {
     commit: '23924f765de3b11b4c09bdc6ea6459a166b75317',
     pages: [
       'examples/hiding-elements/skip-navigation-links',
       'knowledge/keyboard-only/skip-navigation-links'
     ]
-  },
-  {
-    commit: '92cf70a701b23d2dcedb74a8521de7e8cac761b0',
-    pages: ['introduction/about']
   },
   {
     commit: '703b03c2ef4581b27f743e3136d626a3e36edd58',

--- a/gulp/helpers/git-metadata.js
+++ b/gulp/helpers/git-metadata.js
@@ -40,6 +40,7 @@ const getGravatarUrl = email => {
 const changedMetadata = {}
 const fileMergeHistoryCache = {}
 const fileChangeStatsCache = new Map()
+const commitMetadataCache = new Map()
 
 export default () => {
   const parseGitHistory = historyStdout =>
@@ -135,6 +136,38 @@ export default () => {
     return stats
   }
 
+  const getCommitMetadata = commitRef => {
+    if (!commitRef) {
+      return null
+    }
+
+    if (commitMetadataCache.has(commitRef)) {
+      return commitMetadataCache.get(commitRef)
+    }
+
+    const result = childProcess.spawnSync(
+      'git',
+      [
+        'log',
+        '-1',
+        '--pretty=format:%H%x1f%ci%x1f%ct%x1f%an%x1f%ae%x1f%s%x1e',
+        commitRef
+      ],
+      { encoding: 'utf8' }
+    )
+
+    const metadata =
+      result.status === 0 ? parseGitHistory(result.stdout)[0] || null : null
+
+    commitMetadataCache.set(commitRef, metadata)
+
+    if (metadata) {
+      commitMetadataCache.set(metadata.commitId, metadata)
+    }
+
+    return metadata
+  }
+
   const getGitMetadata = filePath => {
     if (changedMetadata[filePath]) {
       return changedMetadata[filePath]
@@ -155,5 +188,10 @@ export default () => {
     return metadata
   }
 
-  return { getGitMetadata, getFileChangeStats, getFileMergeHistory }
+  return {
+    getGitMetadata,
+    getFileChangeStats,
+    getFileMergeHistory,
+    getCommitMetadata
+  }
 }

--- a/gulp/helpers/recent-changes.js
+++ b/gulp/helpers/recent-changes.js
@@ -7,14 +7,17 @@ const MIN_MEANINGFUL_REVISION_LINES = 4
 
 const pathSeparatorRegExp = new RegExp('\\' + path.sep, 'g')
 
-const { getGitMetadata, getFileChangeStats, getFileMergeHistory } =
-  getGitMetadataFactory()
+const {
+  getGitMetadata,
+  getFileChangeStats,
+  getFileMergeHistory,
+  getCommitMetadata
+} = getGitMetadataFactory()
 
 const githubRepoUrl = appConfig.repoUrl
 const mergeOptions = {
   getFileMergeHistory,
-  getFileChangeStats,
-  githubRepoUrl
+  getFileChangeStats
 }
 
 const getCurrentUrl = (filePath, base) => {
@@ -25,6 +28,8 @@ const getCurrentUrl = (filePath, base) => {
     lastSeparatorIndex >= 0 ? relPath.substring(0, lastSeparatorIndex) : ''
   ).replace(pathSeparatorRegExp, '/')
 }
+
+const trim = value => (typeof value === 'string' ? value.trim() : '')
 
 const normalizeRecentPagesConfig = recentPages => {
   if (!Array.isArray(recentPages)) {
@@ -49,7 +54,7 @@ const normalizeRecentPagesConfig = recentPages => {
       continue
     }
 
-    const commit = typeof entry.commit === 'string' ? entry.commit.trim() : ''
+    const commit = trim(entry.commit)
     const pages = Array.isArray(entry.pages)
       ? [
           ...new Set(
@@ -60,9 +65,12 @@ const normalizeRecentPagesConfig = recentPages => {
           )
         ]
       : []
+    const authorCommit = trim(entry.authorCommit)
 
     if (commit && pages.length) {
-      commits.push({ commit, pages })
+      commits.push(
+        authorCommit ? { commit, authorCommit, pages } : { commit, pages }
+      )
     }
   }
 
@@ -85,16 +93,39 @@ const findMergeByCommit = (merges, commitRef) => {
   )
 }
 
-const applyMergeMetadata = (page, merge) => ({
+const commitUrl = commitId =>
+  commitId && githubRepoUrl ? `${githubRepoUrl}/commit/${commitId}` : ''
+
+const applyMetadata = (page, metadata) => ({
   ...page,
-  changed: merge.changed,
-  changedTimestamp: merge.changedTimestamp,
-  changedBy: merge.changedBy,
-  gravatarUrl: merge.gravatarUrl,
-  commitId: merge.commitId,
-  commitMessage: merge.commitMessage,
-  commitUrl: merge.commitUrl
+  changed: metadata.changed,
+  changedTimestamp: metadata.changedTimestamp,
+  changedBy: metadata.changedBy,
+  gravatarUrl: metadata.gravatarUrl,
+  commitId: metadata.commitId,
+  commitMessage: metadata.commitMessage,
+  commitUrl: metadata.commitUrl || commitUrl(metadata.commitId)
 })
+
+const resolveConfiguredPage = (base, { commit, authorCommit }, merges) => {
+  const metadata =
+    findMergeByCommit(merges, commit) || getCommitMetadata(commit)
+  let page = metadata ? applyMetadata(base, metadata) : base
+
+  if (authorCommit) {
+    const author = getCommitMetadata(authorCommit)
+
+    if (author) {
+      page = {
+        ...page,
+        changedBy: author.changedBy,
+        gravatarUrl: author.gravatarUrl
+      }
+    }
+  }
+
+  return page
+}
 
 const isGuideNavigationPage = file => !file.frontMatter.navigation_ignore
 
@@ -122,8 +153,6 @@ const getRecentlyUpdatedPages = ({
     const results = []
 
     for (const item of commits) {
-      const merge = findMergeByCommit(merges, item.commit)
-
       for (const url of item.pages) {
         const base = entryByUrl.get(url)
 
@@ -131,7 +160,7 @@ const getRecentlyUpdatedPages = ({
           continue
         }
 
-        results.push(merge ? applyMergeMetadata(base, merge) : base)
+        results.push(resolveConfiguredPage(base, item, merges))
       }
     }
 
@@ -148,11 +177,7 @@ const isMeaningfulRevision = (linesAdded, linesDeleted) =>
   linesDeleted >= MIN_MEANINGFUL_REVISION_LINES
 
 const groupPageEntriesByMerge = (pages, mergeOptions = {}) => {
-  const {
-    getFileMergeHistory,
-    getFileChangeStats,
-    githubRepoUrl = ''
-  } = mergeOptions
+  const { getFileMergeHistory, getFileChangeStats } = mergeOptions
   const mergesByCommitId = new Map()
 
   for (const page of pages) {
@@ -198,9 +223,7 @@ const groupPageEntriesByMerge = (pages, mergeOptions = {}) => {
         commitId: mergeEntry.commitId,
         commitShortId: mergeEntry.commitId.slice(0, 7),
         commitMessage: mergeEntry.commitMessage,
-        commitUrl: githubRepoUrl
-          ? `${githubRepoUrl}/commit/${mergeEntry.commitId}`
-          : '',
+        commitUrl: commitUrl(mergeEntry.commitId),
         pages: [affectedPage]
       })
     }
@@ -253,9 +276,7 @@ const getUpdatedPageEntries = ({
         gravatarUrl: metadata.gravatarUrl,
         commitId: metadata.commitId,
         commitMessage: metadata.commitMessage,
-        commitUrl: metadata.commitId
-          ? `${githubRepoUrl}/commit/${metadata.commitId}`
-          : ''
+        commitUrl: commitUrl(metadata.commitId)
       }
     })
     .filter(


### PR DESCRIPTION
Improves the home page “Recent changes” author handling and refreshes the curated page list.

- Adds optional authorCommit in config/recent-pages.js to show the contributor instead of the merge commit author
- Resolves metadata from non-merge commits when no matching merge is found
- Updates the list: adds the latest introduction/about change (PR #490) and credits the VMware-on-macOS contributor correctly
https://github.com/Access4all/adg/pull/478