### PR TITLE
feat: improve performance

### DIFF
--- a/gulp/javascript.js
+++ b/gulp/javascript.js
@@ -17,7 +17,7 @@ const {
 export default (config, cb) => {
   const compiler = webpack({
     entry: config.entry,
-    mode: 'development',
+    mode: webpackWatch ? 'development' : 'production',
     module: {
       rules: [
         {

--- a/gulp/javascript.js
+++ b/gulp/javascript.js
@@ -31,10 +31,7 @@ export default (config, cb) => {
                 '@babel/preset-env',
                 {
                   useBuiltIns: 'usage',
-                  corejs: 3,
-                  targets: {
-                    browsers: ['last 2 versions']
-                  }
+                  corejs: 3
                 }
               ]
             ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ import through from 'through2'
 import spritesmith from 'gulp.spritesmith'
 import ordered from 'ordered-read-streams'
 import sharp from 'sharp'
-import concat from 'gulp-concat'
 import changed from 'gulp-changed'
 import html from './gulp/html.js'
 import css from './gulp/css.js'
@@ -94,11 +93,6 @@ gulp.task('js', cb => {
       cb()
     }
   )
-
-  gulp
-    .src('./src/assets/js/lib/vendor/**/*.js')
-    .pipe(concat('vendor.js'))
-    .pipe(gulp.dest('./dist/js/'))
 })
 
 gulp.task(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "core-js": "^3.49.0",
-        "details-polyfill": "^1.2.0",
         "jquery": "^4.0.0"
       },
       "devDependencies": {
@@ -5813,12 +5812,6 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
-    },
-    "node_modules/details-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/details-polyfill/-/details-polyfill-1.2.0.tgz",
-      "integrity": "sha512-jnozpT1eo4c61PGY14Hv1zzqRW+jbrYt8kvd2QwLO9wec0yD0o+3U+CE8SDS4zCRYjZmSedi6Wln5y91VFrZEg==",
-      "license": "MIT"
     },
     "node_modules/detect-file": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "globals": "^17.4.0",
         "gulp": "^5.0.1",
         "gulp-changed": "^5.0.4",
-        "gulp-concat": "^2.6.1",
         "gulp-front-matter": "^1.3.0",
         "gulp-hb": "^8.0.0",
         "gulp-plumber": "^1.2.1",
@@ -5244,16 +5243,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-with-sourcemaps": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
-      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "source-map": "^0.6.1"
-      }
-    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -7494,32 +7483,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/gulp-concat": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
-      "integrity": "sha512-a2scActrQrDBpBbR3WUZGyGS1JEPLg5PZJdIa7/Bi3GuKAmPYDK6SFhy/NZq5R8KsKKFvtfR0fakbUCcKGCCjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "concat-with-sourcemaps": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/gulp-concat/node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
       }
     },
     "node_modules/gulp-front-matter": {
@@ -13381,24 +13344,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/vinyl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
-      "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^2.1.1",
-        "clone-buffer": "^1.0.0",
-        "clone-stats": "^1.0.0",
-        "cloneable-readable": "^1.0.0",
-        "remove-trailing-separator": "^1.0.1",
-        "replace-ext": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/vinyl-bufferstream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vinyl-bufferstream/-/vinyl-bufferstream-1.0.1.tgz",
@@ -13602,16 +13547,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/vinyl/node_modules/replace-ext": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
-      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
   "author": "",
   "license": "ISC",
   "browserslist": [
-    "defaults",
-    "> 1%",
-    "iOS >= 8.4"
+    "defaults"
   ],
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   },
   "dependencies": {
     "core-js": "^3.49.0",
-    "details-polyfill": "^1.2.0",
     "jquery": "^4.0.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "globals": "^17.4.0",
     "gulp": "^5.0.1",
     "gulp-changed": "^5.0.4",
-    "gulp-concat": "^2.6.1",
     "gulp-front-matter": "^1.3.0",
     "gulp-hb": "^8.0.0",
     "gulp-plumber": "^1.2.1",

--- a/src/assets/js/ui.js
+++ b/src/assets/js/ui.js
@@ -1,3 +1,5 @@
+import './lib/vendor/init.js'
+import './lib/vendor/sitesearch360-v12.js'
 import 'details-polyfill'
 import modules from './app/modules.js'
 

--- a/src/assets/js/ui.js
+++ b/src/assets/js/ui.js
@@ -1,6 +1,5 @@
 import './lib/vendor/init.js'
 import './lib/vendor/sitesearch360-v12.js'
-import 'details-polyfill'
 import modules from './app/modules.js'
 
 modules()

--- a/src/templates/layout.hbs
+++ b/src/templates/layout.hbs
@@ -18,8 +18,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <link rel="stylesheet" href="/css/styles.css">
-  <link rel="preload" href="https://fonts.googleapis.com/css?family=Eczar|Work+Sans" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Eczar|Work+Sans"></noscript>
+  <link rel="preload" href="https://fonts.googleapis.com/css?family=Eczar|Work+Sans&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Eczar|Work+Sans&display=swap"></noscript>
   <script src="/js/scripts.js" async></script>
   {{#each metatags.og}}
     <meta property="{{this.property}}" content="{{this.content}}">

--- a/src/templates/layout.hbs
+++ b/src/templates/layout.hbs
@@ -20,10 +20,6 @@
   <link rel="stylesheet" href="/css/styles.css">
   <link rel="preload" href="https://fonts.googleapis.com/css?family=Eczar|Work+Sans" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Eczar|Work+Sans"></noscript>
-  <script>
-  /*! loadCSS rel=preload polyfill. [c]2017 Filament Group, Inc. MIT License */
-  !function(t){"use strict";t.loadCSS||(t.loadCSS=function(){});var e=loadCSS.relpreload={};if(e.support=function(){var e;try{e=t.document.createElement("link").relList.supports("preload")}catch(t){e=!1}return function(){return e}}(),e.bindMediaToggle=function(t){function e(){t.media=a}var a=t.media||"all";t.addEventListener?t.addEventListener("load",e):t.attachEvent&&t.attachEvent("onload",e),setTimeout(function(){t.rel="stylesheet",t.media="only x"}),setTimeout(e,3e3)},e.poly=function(){if(!e.support())for(var a=t.document.getElementsByTagName("link"),n=0;n<a.length;n++){var o=a[n];"preload"!==o.rel||"style"!==o.getAttribute("as")||o.getAttribute("data-loadcss")||(o.setAttribute("data-loadcss",!0),e.bindMediaToggle(o))}},!e.support()){e.poly();var a=t.setInterval(e.poly,500);t.addEventListener?t.addEventListener("load",function(){e.poly(),t.clearInterval(a)}):t.attachEvent&&t.attachEvent("onload",function(){e.poly(),t.clearInterval(a)})}"undefined"!=typeof exports?exports.loadCSS=loadCSS:t.loadCSS=loadCSS}("undefined"!=typeof global?global:this);
-  </script>
   <script src="/js/scripts.js" async></script>
   {{#each metatags.og}}
     <meta property="{{this.property}}" content="{{this.content}}">

--- a/src/templates/layout.hbs
+++ b/src/templates/layout.hbs
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="/css/styles.css">
   <link rel="preload" href="https://fonts.googleapis.com/css?family=Eczar|Work+Sans&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Eczar|Work+Sans&display=swap"></noscript>
-  <script src="/js/scripts.js" async></script>
+  <script src="/js/scripts.js" defer></script>
   {{#each metatags.og}}
     <meta property="{{this.property}}" content="{{this.content}}">
   {{/each}}

--- a/src/templates/layout.hbs
+++ b/src/templates/layout.hbs
@@ -24,6 +24,7 @@
   /*! loadCSS rel=preload polyfill. [c]2017 Filament Group, Inc. MIT License */
   !function(t){"use strict";t.loadCSS||(t.loadCSS=function(){});var e=loadCSS.relpreload={};if(e.support=function(){var e;try{e=t.document.createElement("link").relList.supports("preload")}catch(t){e=!1}return function(){return e}}(),e.bindMediaToggle=function(t){function e(){t.media=a}var a=t.media||"all";t.addEventListener?t.addEventListener("load",e):t.attachEvent&&t.attachEvent("onload",e),setTimeout(function(){t.rel="stylesheet",t.media="only x"}),setTimeout(e,3e3)},e.poly=function(){if(!e.support())for(var a=t.document.getElementsByTagName("link"),n=0;n<a.length;n++){var o=a[n];"preload"!==o.rel||"style"!==o.getAttribute("as")||o.getAttribute("data-loadcss")||(o.setAttribute("data-loadcss",!0),e.bindMediaToggle(o))}},!e.support()){e.poly();var a=t.setInterval(e.poly,500);t.addEventListener?t.addEventListener("load",function(){e.poly(),t.clearInterval(a)}):t.attachEvent&&t.attachEvent("onload",function(){e.poly(),t.clearInterval(a)})}"undefined"!=typeof exports?exports.loadCSS=loadCSS:t.loadCSS=loadCSS}("undefined"!=typeof global?global:this);
   </script>
+  <script src="/js/scripts.js" async></script>
   {{#each metatags.og}}
     <meta property="{{this.property}}" content="{{this.content}}">
   {{/each}}
@@ -71,7 +72,5 @@
       {{> "global/footer/footer"}}
     </div>
   </div>
-  <script src="/js/vendor.js"></script>
-  <script src="/js/scripts.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR slightly improves performance by reducing the JavaScript payload and improving font display behavior.

Refs #184 

JavaScript payload:
- Before: `vendor.js` and `scripts.js`: 199 kB
- After: `scripts.js` (including `vendor.js`): 76 kB

Mobile Lighthouse score increases from ~90 to ~95.

Further improvements would depend on a JavaScript refactoring (e.g. loading the complete search stuff async).